### PR TITLE
use sdk-starter.bat instead of specific file

### DIFF
--- a/extension/BuildPhpExtension/private/Add-Extension.ps1
+++ b/extension/BuildPhpExtension/private/Add-Extension.ps1
@@ -42,7 +42,7 @@ Function Add-Extension {
         $bat_content += "nmake /nologo 2>&1"
         $bat_content += "exit %errorlevel%"
         Set-Content -Encoding "ASCII" -Path $Extension-task.bat -Value $bat_content
-        $builder = "$currentDirectory\php-sdk\phpsdk-$($Config.vs_version)-$($Config.Arch).bat"
+        $builder = "$currentDirectory\php-sdk\phpsdk-starter.bat"
         $task = (Get-Item -Path "." -Verbose).FullName + "\$Extension-task.bat"
         $suffix = "php_" + (@(
             $Config.name,
@@ -52,7 +52,7 @@ Function Add-Extension {
             $Config.vs_version,
             $Config.arch
         ) -join "-")
-        & $builder -t $task | Tee-Object -FilePath "build-$suffix.txt"
+        & $builder -c $Config.vs_version -a $Config.Arch -t $task | Tee-Object -FilePath "build-$suffix.txt"
         $includePath = "$currentDirectory\php-dev\include"
         New-Item -Path $includePath\ext -Name $Extension -ItemType "directory" | Out-Null
         Get-ChildItem -Path (Get-Location).Path -Recurse -Include '*.h', '*.c' | Copy-Item -Destination "$includePath\ext\$Extension"

--- a/extension/BuildPhpExtension/private/Invoke-Build.ps1
+++ b/extension/BuildPhpExtension/private/Invoke-Build.ps1
@@ -24,7 +24,7 @@ Function Invoke-Build {
             $bat_content += "exit %errorlevel%"
             Set-Content -Encoding "ASCII" -Path task.bat -Value $bat_content
 
-            $builder = "php-sdk\phpsdk-$($Config.vs_version)-$($Config.Arch).bat"
+            $builder = "php-sdk\phpsdk-starter.bat"
             $task = (Get-Item -Path "." -Verbose).FullName + '\task.bat'
             $ref = $Config.ref
             if($env:ARTIFACT_NAMING_SCHEME -eq 'pecl') {
@@ -38,7 +38,7 @@ Function Invoke-Build {
                 $Config.vs_version,
                 $Config.arch
             ) -join "-")
-            & $builder -s $Config.vs_toolset -t $task | Tee-Object -FilePath "build-$suffix.txt"
+            & $builder -c $Config.vs_version -a $Config.Arch -s $Config.vs_toolset -t $task | Tee-Object -FilePath "build-$suffix.txt"
             Set-GAGroup end
             Add-BuildLog tick $Config.name "Extension $($Config.name) built successfully"
         } catch {

--- a/php/BuildPhp/public/Invoke-PhpBuild.ps1
+++ b/php/BuildPhp/public/Invoke-PhpBuild.ps1
@@ -53,7 +53,7 @@ function Invoke-PhpBuild {
 
         $task = "$PSScriptRoot\..\runner\task-$Ts.bat"
 
-        & "$buildDirectory\php-sdk\phpsdk-$VsVersion-$Arch.bat" -t $task
+        & "$buildDirectory\php-sdk\phpsdk-starter.bat" -c $VsVersion -a $Arch -t $task
         if (-not $?) {
             throw "build failed with errorlevel $LastExitCode"
         }


### PR DESCRIPTION
This action calls the script named `sdk-<vs_version>-<arch>.bat` to enable the PHP building environment.

This behavior cannot allow executing this action on a new Visual Studio version or processor architecture without adding files into the PHP SDK before.

All `sdk-<vs_version>-<arch>.bat` scripts call the script `sdk-starter.bat` with predefined arguments for VS version and architecture.

This PR changes the script called for `sdk-starter.bat` to allow execution of this action without the need to add new files in PHP SDK.