### PR TITLE
Make artifact format more obvious

### DIFF
--- a/extension/BuildPhpExtension/private/Add-Package.ps1
+++ b/extension/BuildPhpExtension/private/Add-Package.ps1
@@ -104,7 +104,7 @@ function Add-Package {
                     }
                 }
             }
-            Add-Content "artifact=$artifact" -Path $env:GITHUB_OUTPUT -Encoding utf8
+            Add-Content "artifact=$artifact.zip" -Path $env:GITHUB_OUTPUT -Encoding utf8
 
             7z a -sdel "$artifact.zip" *
 


### PR DESCRIPTION
When downloading artifacts, there should be a file extension displayed, so everyone knows what will be downloaded.